### PR TITLE
Reuse Check-in QR Code fix

### DIFF
--- a/fiftySix/app/src/main/java/com/example/fiftysix/AdminBrowseProfiles.java
+++ b/fiftySix/app/src/main/java/com/example/fiftysix/AdminBrowseProfiles.java
@@ -14,7 +14,7 @@ import com.google.firebase.firestore.FirebaseFirestore;
 import java.util.ArrayList;
 import java.util.List;
 
-public class AdminBrowseProfiles extends AppCompatActivity {
+public class  AdminBrowseProfiles extends AppCompatActivity {
     private RecyclerView recyclerView;
     private AdminProfileAdapter adapter;
     private FirebaseFirestore db;

--- a/fiftySix/app/src/main/java/com/example/fiftysix/CheckInQRCode.java
+++ b/fiftySix/app/src/main/java/com/example/fiftysix/CheckInQRCode.java
@@ -113,16 +113,20 @@ public class CheckInQRCode{
      * @param callback Used as a function point to store a boolean, true if QR can be reused, false if not.
      */
     public void checkValidReuseQR(String reuseQRId, CheckInQRCodeCallback callback){
-        qrRef.document(reuseQRId).get().addOnSuccessListener(new OnSuccessListener<DocumentSnapshot>() {
+        FirebaseFirestore.getInstance().collection("CheckInQRCode").document(reuseQRId).get().addOnSuccessListener(new OnSuccessListener<DocumentSnapshot>() {
             @Override
             public void onSuccess(DocumentSnapshot documentSnapshot) {
                 if ( (documentSnapshot.exists()) && (documentSnapshot != null) && (documentSnapshot.getString("event") != null) ){
                     String oldEventId = documentSnapshot.getString("event");
 
-                    db.collection("Events").document(oldEventId).get().addOnSuccessListener(new OnSuccessListener<DocumentSnapshot>() {
+
+
+                    FirebaseFirestore.getInstance().collection("Events").document(oldEventId).get().addOnSuccessListener(new OnSuccessListener<DocumentSnapshot>() {
                         @Override
                         public void onSuccess(DocumentSnapshot dSnapshot) {
                             if ( (dSnapshot.exists()) && (dSnapshot != null) && (dSnapshot.getString("endDate") != null) ){
+
+
                                 String endDate = dSnapshot.getString("endDate");
                                 SimpleDateFormat sdf = new SimpleDateFormat("dd/MM/yy");
                                 Date strDate = null;
@@ -149,6 +153,8 @@ public class CheckInQRCode{
                 }
                 else{
                     callback.onSuccess(false);
+
+
                 }
             }
         });

--- a/fiftySix/app/src/main/java/com/example/fiftysix/CheckInQRCode.java
+++ b/fiftySix/app/src/main/java/com/example/fiftysix/CheckInQRCode.java
@@ -17,6 +17,7 @@ import com.google.android.gms.tasks.OnFailureListener;
 import com.google.android.gms.tasks.OnSuccessListener;
 import com.google.firebase.database.FirebaseDatabase;
 import com.google.firebase.firestore.CollectionReference;
+import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.FirebaseFirestore;
 import com.google.firebase.storage.FirebaseStorage;
 import com.google.firebase.storage.StorageReference;
@@ -28,7 +29,10 @@ import com.google.zxing.common.BitMatrix;
 import com.journeyapps.barcodescanner.BarcodeEncoder;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.Calendar;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -79,6 +83,14 @@ public class CheckInQRCode{
 
     }
 
+    public CheckInQRCode() {
+    }
+
+    public interface CheckInQRCodeCallback {
+        void onSuccess(Boolean validQR);
+        void onFailure(Exception e);
+    }
+
 
     // Basic Getters & Setters.
     public String getEventID() {
@@ -91,6 +103,59 @@ public class CheckInQRCode{
         return qrCode;
     }
     public String getQRCodeID(){ return qrCodeID; }
+
+
+    /**
+     * Checks if the QRCode is eligible for reuse. To be allowed it must belong to a previous event created in our app (exists in the database),
+     * and the event must be atleast one of an event that isw finished (finish date has past by 1 day) or event was deleted by the admin.
+     * Not allowed to reuse QRCode from active events.
+     * @param reuseQRId String of the QR code id that we would like to check if it can be reviewed
+     * @param callback Used as a function point to store a boolean, true if QR can be reused, false if not.
+     */
+    public void checkValidReuseQR(String reuseQRId, CheckInQRCodeCallback callback){
+        qrRef.document(reuseQRId).get().addOnSuccessListener(new OnSuccessListener<DocumentSnapshot>() {
+            @Override
+            public void onSuccess(DocumentSnapshot documentSnapshot) {
+                if ( (documentSnapshot.exists()) && (documentSnapshot != null) && (documentSnapshot.getString("event") != null) ){
+                    String oldEventId = documentSnapshot.getString("event");
+
+                    db.collection("Events").document(oldEventId).get().addOnSuccessListener(new OnSuccessListener<DocumentSnapshot>() {
+                        @Override
+                        public void onSuccess(DocumentSnapshot dSnapshot) {
+                            if ( (dSnapshot.exists()) && (dSnapshot != null) && (dSnapshot.getString("endDate") != null) ){
+                                String endDate = dSnapshot.getString("endDate");
+                                SimpleDateFormat sdf = new SimpleDateFormat("dd/MM/yy");
+                                Date strDate = null;
+                                try {
+                                    strDate = sdf.parse(endDate);
+                                } catch (ParseException e) {
+                                    throw new RuntimeException(e);
+                                }
+                                if (new Date().after(strDate)) {
+                                    //Event is old and in our database. can be reused.
+                                    callback.onSuccess(true);
+                                } else {
+                                    callback.onSuccess(false);
+                                }
+                            }
+
+                            // Event was deletds by admin and can use QR code again
+                            else{
+                                callback.onSuccess(true);
+                            }
+                        }
+                    });
+
+                }
+                else{
+                    callback.onSuccess(false);
+                }
+            }
+        });
+
+
+    }
+
 
 
     // Generates a QR code (Bitmap) containing a string of the eventID. Adds image of qr code and event data to firebase.

--- a/fiftySix/app/src/main/java/com/example/fiftysix/Event.java
+++ b/fiftySix/app/src/main/java/com/example/fiftysix/Event.java
@@ -17,6 +17,8 @@ import com.google.firebase.firestore.CollectionReference;
 import com.google.firebase.firestore.DocumentReference;
 import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.storage.FirebaseStorage;
+import com.google.firebase.storage.StorageReference;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -118,8 +120,8 @@ public class Event {
         // TODO: check the the event that we are reusing the qrcode from is still active.
 
         // Switches data
-        FirebaseFirestore.getInstance().collection("Events").document(this.eventID).update("checkInQRCode", checkInQRCodeID);
-        FirebaseFirestore.getInstance().collection("CheckInQRCode").document(this.checkInQRCodeID).update("event", this.eventID);
+        db.collection("Events").document(this.eventID).update("checkInQRCode", checkInQRCodeID);
+        db.collection("CheckInQRCode").document(this.checkInQRCodeID).update("event", this.eventID);
 
     }
 
@@ -127,7 +129,16 @@ public class Event {
     // ________________________________METHODS_____________________________________
 
     public void setPromoQR(String promoQRCodeID){
-        FirebaseFirestore.getInstance().collection("Events").document(this.eventID).update("promoQRCode", promoQRCodeID);
+        db.collection("Events").document(this.eventID).update("promoQRCode", promoQRCodeID);
+    }
+
+    public void reuseCheckInQR(String reuseQRCodeID){
+        db.collection("Events").document(this.eventID).update("checkInQRCode", reuseQRCodeID);
+        db.collection("CheckInQRCode").document(reuseQRCodeID).update("event", this.eventID);
+
+        // Delets new checkin QRCode created
+        db.collection("CheckInQRCode").document(this.checkInQRCodeID).delete();
+        FirebaseStorage.getInstance().getReference().child("images/checkInQRCode/" + this.checkInQRCodeID).delete();
     }
 
 

--- a/fiftySix/app/src/main/java/com/example/fiftysix/Organizer.java
+++ b/fiftySix/app/src/main/java/com/example/fiftysix/Organizer.java
@@ -80,7 +80,35 @@ public class Organizer {
      *
      * @return String posterID key
      */
-    public String createEventNewQRCode( String details, String location, Integer attendeeCheckInLimit, Integer attendeeSignUpLimit, String eventName, String startDate, String endDate, String startTime, String endTime, PromoQRCode promoQRCode){
+    public String createEventNewQRCode( String details, String location, Integer attendeeCheckInLimit, Integer attendeeSignUpLimit, String eventName, String startDate, String endDate, String startTime, String endTime, PromoQRCode promoQRCode, String reuseQRID){
+        Event event = new Event(this.organizerID, details, location, attendeeCheckInLimit, attendeeSignUpLimit, eventName, startDate, endDate, startTime, endTime, mContext);
+        addEventToOrganizerDataBase(event.getEventID());
+
+        String eventID = event.getEventID();
+
+        if (promoQRCode != null){
+            promoQRCode.setEvent(eventID);
+            event.setPromoQR(promoQRCode.getQRCodeID());
+        }
+        if (reuseQRID != null){
+            event.reuseCheckInQR(reuseQRID);
+        }
+
+        return event.getPosterID();
+    }
+
+
+    /**
+     * Creates a new event and switches the event that the oldQRID points to, it now points to the new event in the firebase database.
+     * The event is then added to EventsByOrganizer collection inside the organizers document in firebase.
+     * @param details String of the event details
+     * @param location String of the event location
+     *
+     * @param eventName String of the event name
+     * @param oldQRID String of the old QR code id to be reused
+     */
+    /*
+    public String createEventReuseQRCode( String details, String location, Integer attendeeCheckInLimit, Integer attendeeSignUpLimit, String eventName, String startDate, String endDate, String startTime, String endTime, PromoQRCode promoQRCode, String reuseQRID){
         Event event = new Event(this.organizerID, details, location, attendeeCheckInLimit, attendeeSignUpLimit, eventName, startDate, endDate, startTime, endTime, mContext);
         addEventToOrganizerDataBase(event.getEventID());
 
@@ -94,20 +122,8 @@ public class Organizer {
         return event.getPosterID();
     }
 
-    /**
-     * Creates a new event and switches the event that the oldQRID points to, it now points to the new event in the firebase database.
-     * The event is then added to EventsByOrganizer collection inside the organizers document in firebase.
-     * @param details String of the event details
-     * @param location String of the event location
-     *
-     * @param eventName String of the event name
-     * @param oldQRID String of the old QR code id to be reused
      */
-    public void createEventReuseQRCode(String details, String location, Integer attendeeCheckInLimit, Integer attendeeSignUpLimit, String eventName, String oldQRID){
-        Event event = new Event(this.organizerID, details, location, attendeeCheckInLimit, attendeeSignUpLimit, eventName, mContext, oldQRID);
 
-        addEventToOrganizerDataBase(event.getEventID());
-    }
 
 
     public void createPromoQRCode(){}

--- a/fiftySix/app/src/main/java/com/example/fiftysix/OrganizerMainActivity.java
+++ b/fiftySix/app/src/main/java/com/example/fiftysix/OrganizerMainActivity.java
@@ -709,7 +709,10 @@ public class OrganizerMainActivity extends AppCompatActivity {
 
     /**
      *  Reference - "youtube - Implement Barcode QR Scanner in Android studio barcode reader | Cambo Tutorial" - youtube channel = Cambo Tutorial
-     *  Scans QR code, gets the string. This string returned as a unique QRCode id.
+     *  Scans QR code, gets the string. This string returned as a unique QRCode id. It then checks if the QR code is elidible for reuse as a checckin QR Code.
+     *  Criteria for eligibility is:
+     *  1. Belongs to an INACTIVE event.
+     *  2. Was a CHECK-IN QR code on this app.
      */
     private void scanCode () {
             ScanOptions options = new ScanOptions();
@@ -722,35 +725,58 @@ public class OrganizerMainActivity extends AppCompatActivity {
         ActivityResultLauncher<ScanOptions> barLauncher = registerForActivityResult(new ScanContract(), result -> {
 
             if (result.getContents() != null) {
-                AlertDialog.Builder builder = new AlertDialog.Builder(OrganizerMainActivity.this);
-                builder.setTitle("Result");
-                builder.setMessage(result.getContents());
-                builder.setPositiveButton("OK", new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int which) {
+
                         scanQRID = result.getContents().toString();
                         SimpleDateFormat sdf = new SimpleDateFormat("dd/MM/yy");
                         Date strDate = null;
+
+
+
 
                         new CheckInQRCode().checkValidReuseQR(scanQRID, new CheckInQRCode.CheckInQRCodeCallback() {
                             @Override
                             public void onSuccess(Boolean validQR) {
                                 if (validQR){
                                     reuseQRID = scanQRID;
+
+
+                                    new AlertDialog.Builder(OrganizerMainActivity.this)
+                                            .setTitle("QR Code Set")
+                                            .setMessage("Your QR code was successfully set.")
+                                            .setPositiveButton(android.R.string.yes, new DialogInterface.OnClickListener() {
+                                                public void onClick(DialogInterface dialog, int which) {
+                                                    dialog.dismiss();
+                                                }
+                                            })
+                                            .show();
+
+
+                                }else{
+                                    new AlertDialog.Builder(OrganizerMainActivity.this)
+                                            .setTitle("QR Code Not Eligible")
+                                            .setMessage("A QR code is not eligible if:\n1. Belongs to an active or upcoming event.\n2. Was never used as a CHECK-IN QR code on this app, ALL Promo QR Codes are ineligible.")
+                                            .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
+                                                public void onClick(DialogInterface dialog, int which) {
+                                                    dialog.dismiss();
+                                                }
+                                            })
+                                            .show();
                                 }
                             }
 
                             @Override
                             public void onFailure(Exception e) {
 
+
+
+
                             }
                         });
 
 
-                        dialog.dismiss();
                     }
-                }).show();
-            }
+
+
 
         });
 

--- a/fiftySix/app/src/main/java/com/example/fiftysix/Profile.java
+++ b/fiftySix/app/src/main/java/com/example/fiftysix/Profile.java
@@ -147,14 +147,6 @@ public class Profile {
 
 
 
-    private boolean profileInDataBase(){
-        return (FirebaseDatabase.getInstance().getReference("Users/"+userID+"/name") != null );
-
-    }
-
-
-
-
     private void addProfileToDatabase(){
         Map<String,Object> profileData = new HashMap<>();
         profileData.put("userID","unknown");


### PR DESCRIPTION
Now ONLY lets organizers reuse QR codes that were:
1. Previously a check-in QR code on this app (Must exist in data base and cannot be a promotion QR code)
2. Does not belong to an active or upcoming event (Must be an event that is 1 day past it's end date or have been deleted by admin)